### PR TITLE
macOS demos: All demos successfully run on macOS

### DIFF
--- a/progs/demos/smooth_opengl3/smooth_opengl3.c
+++ b/progs/demos/smooth_opengl3/smooth_opengl3.c
@@ -234,6 +234,29 @@ void initBuffer(void)
    checkError ("initBuffer");
 }
 
+#ifdef __APPLE__
+const ourGLchar *vertexShaderSource[] = {
+   "#version 120\n",
+   "uniform mat4 fg_ProjectionMatrix;\n",
+   "attribute vec4 fg_Color;\n",
+   "attribute vec4 fg_Vertex;\n",
+   "varying vec4 fg_SmoothColor;\n",
+   "void main()\n",
+   "{\n",
+   "   fg_SmoothColor = fg_Color;\n",
+   "   gl_Position = fg_ProjectionMatrix * fg_Vertex;\n",
+   "}\n"
+};
+
+const ourGLchar *fragmentShaderSource[] = {
+   "#version 120\n",
+   "varying vec4 fg_SmoothColor;\n",
+   "void main(void)\n",
+   "{\n",
+   "   gl_FragColor = fg_SmoothColor;\n",
+   "}\n"
+};
+#else
 const ourGLchar *vertexShaderSource[] = {
    "#version 140\n",
    "uniform mat4 fg_ProjectionMatrix;\n",
@@ -256,6 +279,7 @@ const ourGLchar *fragmentShaderSource[] = {
    "   fg_FragColor = fg_SmoothColor;\n",
    "}\n"
 };
+#endif
 
 void compileAndCheck(GLuint shader)
 {


### PR DESCRIPTION
Notes:
 - All demos run successfully
 - Supports GLSL ≤1.20 or ≥1.50 (not 1.40)
 - Using 1.20 for compatibility profile
 - `smooth` qualifier:
   - Not supported in 1.20 but behavior is implicit default
   - GL_EXT_gpu_shader4 adds: noperspective, flat, centroid